### PR TITLE
Update example for zig version 0.6.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 
-BUILD_FLAGS = --release-small -target thumbv7m-freestanding-none
+BUILD_FLAGS = --release-small -target thumb-freestanding -mcpu cortex_m3
 LINKER_SCRIPT = arm_cm3.ld
 LD_FLAGS = --gc-sections -nostdlib
 OBJS = startup.o main.o

--- a/main.zig
+++ b/main.zig
@@ -3,8 +3,8 @@ usingnamespace @import("stm32f10.zig");
 export fn main() void {
     SystemInit();
     RCC.*.APB2ENR |= RCC_APB2Periph_GPIOC; // enable GPIOC clk
-    GPIOC.*.CRH &= ~u32(0b1111 << 20); // PC13
-    GPIOC.*.CRH |= u32(0b0010 << 20); // Out PP, 2MHz
+    GPIOC.*.CRH &= ~@as(u32, 0b1111 << 20); // PC13
+    GPIOC.*.CRH |= @as(u32, 0b0010 << 20); // Out PP, 2MHz
 
     while (true) {
         GPIOC.*.ODR ^= GPIO_PIN_13; // toggle

--- a/stm32f10.zig
+++ b/stm32f10.zig
@@ -74,19 +74,20 @@ pub const FLASH = @intToPtr(*volatile FLASH_t, FLASH_R_BASE);
 pub fn SystemInit() void {
     //* Reset the RCC clock configuration to the default reset state(for debug purpose) */
     //* Set HSION bit */
-    RCC.*.CR |= u32(0x00000001);
+    RCC.*.CR |= @as(u32, 0x00000001);
+
 
     //* Reset SW, HPRE, PPRE1, PPRE2, ADCPRE and MCO bits */
-    RCC.*.CFGR &= u32(0xF8FF0000);
+    RCC.*.CFGR &= @as(u32, 0xF8FF0000);
 
     //* Reset HSEON, CSSON and PLLON bits */
-    RCC.*.CR &= u32(0xFEF6FFFF);
+    RCC.*.CR &= @as(u32, 0xFEF6FFFF);
 
     //* Reset HSEBYP bit */
-    RCC.*.CR &= u32(0xFFFBFFFF);
+    RCC.*.CR &= @as(u32, 0xFFFBFFFF);
 
     //* Reset PLLSRC, PLLXTPRE, PLLMUL and USBPRE/OTGFSPRE bits */
-    RCC.*.CFGR &= u32(0xFF80FFFF);
+    RCC.*.CFGR &= @as(u32, 0xFF80FFFF);
 
     //* Disable all interrupts and clear pending bits  */
     RCC.*.CIR = 0x009F0000;
@@ -104,7 +105,7 @@ fn SetSysClock() void {
 
     //* SYSCLK, HCLK, PCLK2 and PCLK1 configuration ---------------------------*/
     //* Enable HSE */
-    RCC.*.CR |= u32(RCC_CR_HSEON);
+    RCC.*.CR |= RCC_CR_HSEON;
 
     //* Wait till HSE is ready and if Time out is reached exit */
     HSEStatus = RCC.*.CR & RCC_CR_HSERDY;
@@ -122,24 +123,24 @@ fn SetSysClock() void {
 
     if (HSEStatus == 0x01) {
         //* Enable Prefetch Buffer */
-        FLASH.*.ACR |= FLASH_ACR_PRFTBE;
+        FLASH.*.ACR |= @as(u32, FLASH_ACR_PRFTBE);
 
         //* Flash 2 wait state */
-        FLASH.*.ACR &= u32(~FLASH_ACR_LATENCY);
-        FLASH.*.ACR |= u32(FLASH_ACR_LATENCY_2);
+        FLASH.*.ACR &= @as(u32, ~FLASH_ACR_LATENCY);
+        FLASH.*.ACR |= @as(u32, FLASH_ACR_LATENCY_2);
 
         //* HCLK = SYSCLK */
-        RCC.*.CFGR |= u32(RCC_CFGR_HPRE_DIV1);
+        RCC.*.CFGR |= RCC_CFGR_HPRE_DIV1;
 
         //* PCLK2 = HCLK */
-        RCC.*.CFGR |= u32(RCC_CFGR_PPRE2_DIV1);
+        RCC.*.CFGR |= RCC_CFGR_PPRE2_DIV1;
 
         //* PCLK1 = HCLK */
-        RCC.*.CFGR |= u32(RCC_CFGR_PPRE1_DIV2);
+        RCC.*.CFGR |= RCC_CFGR_PPRE1_DIV2;
 
         //*  PLL configuration: PLLCLK = HSE * 9 = 72 MHz */
-        RCC.*.CFGR &= u32(~u32(RCC_CFGR_PLLSRC | RCC_CFGR_PLLXTPRE | RCC_CFGR_PLLMULL));
-        RCC.*.CFGR |= u32(RCC_CFGR_PLLSRC_HSE | RCC_CFGR_PLLMULL9);
+        RCC.*.CFGR &= ~(RCC_CFGR_PLLSRC | RCC_CFGR_PLLXTPRE | RCC_CFGR_PLLMULL);
+        RCC.*.CFGR |= RCC_CFGR_PLLSRC_HSE | RCC_CFGR_PLLMULL9;
 
         //* Enable PLL */
         RCC.*.CR |= RCC_CR_PLLON;
@@ -148,11 +149,11 @@ fn SetSysClock() void {
         while ((RCC.*.CR & RCC_CR_PLLRDY) == 0) {}
 
         //* Select PLL as system clock source */
-        RCC.*.CFGR &= u32(~u32(RCC_CFGR_SW));
-        RCC.*.CFGR |= u32(RCC_CFGR_SW_PLL);
+        RCC.*.CFGR &= ~RCC_CFGR_SW;
+        RCC.*.CFGR |= RCC_CFGR_SW_PLL;
 
         //* Wait till PLL is used as system clock source */
-        while ((RCC.*.CFGR & u32(RCC_CFGR_SWS)) != u32(0x08)) {}
+        while ((RCC.*.CFGR & RCC_CFGR_SWS) != @as(u32, 0x08)) {}
     } else { //* If HSE fails to start-up, the application will have wrong clock
         //  configuration. User can add here some code to deal with this error */
     }


### PR DESCRIPTION
Update casting to use `@as` builtin instead of calling type as a
function as per <https://ziglang.org/download/0.6.0/release-notes.html#Type-Coercion-Syntax>
Also removed a few places where casting wasn't needed as both the
literal value and destination register are already 32-bits wide.

Update Makefile to make use of new CPU model awareness.
<https://ziglang.org/download/0.6.0/release-notes.html#Target-Details>